### PR TITLE
Fix GLAM-SLAM paper metadata and restore links

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,7 +499,7 @@ For an overview of 3D Gaussian Splatting papers, checkout the Repository ([aweso
 - **Flow4DGS-SLAM:** Optical Flow-Guided 4D Gaussian Splatting SLAM, *CVPR, 2026*. [[Paper](https://arxiv.org/pdf/2604.22339)] [[Code](https://github.com/wangys16/Flow4DGS-SLAM)]
 - **GAD-SLAM**: 2D Gaussian splatting SLAM via active densification, *Displays, 2026*. [[Paper](https://www.sciencedirect.com/science/article/pii/S0141938226001393)]
 - **GaussianFlow SLAM**: Monocular Gaussian Splatting SLAM Guided by GaussianFlow, *RAL, 2026*. [[Paper](https://arxiv.org/pdf/2604.15612)] [[Code](https://github.com/url-kaist/gaussianflow-slam)]
-- **GLAM-SLAM**: Real-time Gaussian Large-scale Mapping via Flow Densification and Spatial Decomposition, *arXiv, 2026*. [[Paper](https://arxiv.org/pdf/2607.24495)]
+- **GLAM-SLAM**: Real-time Gaussian Large-scale Mapping via Flow Densification and Spatial Decomposition, *IROS, 2026*. [[Paper](https://arxiv.org/pdf/2607.21416)] [[Website](https://glamslam.github.io/)] [[Code](https://github.com/pmermigkas/GLAM-SLAM)]
 - **NSL-SLAM**: High-Fidelity Neural Structured-Light Depth for Practical SLAM and Reconstruction, *arXiv, 2026*. [[Paper](https://arxiv.org/pdf/2607.24495)]
 - **MGS-SLAM**: Monocular 3D Gaussian splatting SLAM with significance-guided pruning, *CVMJ, 2026*. [[Paper](https://ieeexplore.ieee.org/abstract/document/11623389)]
 - **DynGS-SLAM**: dynamic-aware Gaussian splatting for robust dense SLAM, *Machine Vision and Applications, 2026*. [[Paper](https://link.springer.com/article/10.1007/s00138-026-01887-w)]


### PR DESCRIPTION
## Problem

The current GLAM-SLAM entry points to arXiv `2607.24495`, which is also used by the following NSL-SLAM entry. The official GLAM-SLAM paper is arXiv `2607.21416`, and the work is accepted at IROS 2026.

## Change

- Correct the paper link
- Update the venue to IROS 2026
- Add the official project page
- Add the public code repository

## Sources

- Paper: https://arxiv.org/abs/2607.21416
- Project: https://glamslam.github.io/
- Code: https://github.com/pmermigkas/GLAM-SLAM

This is a one-line metadata correction.